### PR TITLE
Use Lxc Container for Molecule Tests

### DIFF
--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -53,11 +53,11 @@ jobs:
 
       - name: iptables set-up
         run: |
-          iptables -P INPUT ACCEPT
-          iptables -P FORWARD ACCEPT
-          iptables -P OUTPUT ACCEPT
-          iptables -F
-          iptables -X
+          sudo iptables -P INPUT ACCEPT
+          sudo iptables -P FORWARD ACCEPT
+          sudo iptables -P OUTPUT ACCEPT
+          sudo iptables -F
+          sudo iptables -X
 
       - name: nat set-up
         run: |

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -47,9 +47,13 @@ jobs:
           install -m 0700 -d ~/.ssh/
           ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N ''
 
+      - name: list iptables rules
+        run: |
+          sudo iptables -L
+
       - name: nat set-up
         run: |
-          sudo iptables -t nat -A POSTROUTING -s '10.0.3.1/24' -o eth0 -j MASQUERADE
+          sudo iptables -t nat -A POSTROUTING -s '10.0.3.0/24' -o eth0 -j MASQUERADE
 
       - name: test server
         run: |
@@ -61,6 +65,7 @@ jobs:
         run: |
           set -eux
           ip a
+          ip r
           route
           ping -c3 test.el9
           cat /etc/lxc/default.conf
@@ -72,6 +77,10 @@ jobs:
           sudo lxc-attach -n el9 -- ip r
           sudo lxc-attach -n el9 -- cat /etc/resolv.conf
           sudo lxc-attach -n el9 -- curl -vvv -4 -I http://10.0.3.1:8000
+
+      - name: tests eytern http
+        run: |
+          curl -vvv -4 -I https://lkiesow.de
           sudo lxc-attach -n el9 -- curl -vvv -4 -I https://lkiesow.de
 
       - name: configure sshd

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -49,11 +49,14 @@ jobs:
 
       - name: tests
         run: |
+          set -eux
           ip a
+          ping -n3 test.el9
           sudo lxc-attach -n el9 -- ip a
           sudo lxc-attach -n el9 -- cat /etc/resolv.conf
-          sudo lxc-attach -n el9 -- curl -4 -I google.com
+          sudo lxc-attach -n el9 -- ping -6 -n3 google.com
           sudo lxc-attach -n el9 -- curl -6 -I google.com
+          sudo lxc-attach -n el9 -- curl -4 -I google.com
 
       - name: configure sshd
         run: |

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -51,10 +51,12 @@ jobs:
         run: |
           set -eux
           ip a
-          ping -n3 test.el9
+          ping -c3 test.el9
+          ping -4 -c3 google.com
+          ping -6 -c3 google.com
           sudo lxc-attach -n el9 -- ip a
           sudo lxc-attach -n el9 -- cat /etc/resolv.conf
-          sudo lxc-attach -n el9 -- ping -6 -n3 google.com
+          sudo lxc-attach -n el9 -- ping -6 -c3 google.com
           sudo lxc-attach -n el9 -- curl -6 -I google.com
           sudo lxc-attach -n el9 -- curl -4 -I google.com
 

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -51,13 +51,13 @@ jobs:
           install -m 0700 -d ~/.ssh/
           ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N ''
 
-      - name: list iptables rules
-        run: |
-          sudo iptables -L
-
       - name: nat set-up
         run: |
           sudo iptables -t nat -A POSTROUTING -s '10.0.3.0/24' -o eth0 -j MASQUERADE
+
+      - name: list iptables rules
+        run: |
+          sudo iptables -L
 
       - name: test server
         run: |

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -47,6 +47,10 @@ jobs:
           install -m 0700 -d ~/.ssh/
           ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N ''
 
+      - name: nat set-up
+        run: |
+          sudo iptables -t nat -A POSTROUTING -s '10.0.3.1/24' -o eth0 -j MASQUERADE
+
       - name: test server
         run: |
           set -eux
@@ -56,19 +60,19 @@ jobs:
       - name: tests
         run: |
           set -eux
-          stdbuf -o0 ip a
-          stdbuf -o0 route
-          stdbuf -o0 ping -c3 test.el9
-          stdbuf -o0 cat /etc/lxc/default.conf
+          ip a
+          route
+          ping -c3 test.el9
+          cat /etc/lxc/default.conf
 
       - name: tests
         run: |
           set -eux
-          stdbuf -o0 sudo lxc-attach -n el9 -- ip a
-          stdbuf -o0 sudo lxc-attach -n el9 -- ip r
-          stdbuf -o0 sudo lxc-attach -n el9 -- cat /etc/resolv.conf
-          stdbuf -o0 sudo lxc-attach -n el9 -- curl -vvv -4 -I http://10.0.3.1:8000
-          stdbuf -o0 sudo lxc-attach -n el9 -- curl -vvv -4 -I https://lkiesow.de
+          sudo lxc-attach -n el9 -- ip a
+          sudo lxc-attach -n el9 -- ip r
+          sudo lxc-attach -n el9 -- cat /etc/resolv.conf
+          sudo lxc-attach -n el9 -- curl -vvv -4 -I http://10.0.3.1:8000
+          sudo lxc-attach -n el9 -- curl -vvv -4 -I https://lkiesow.de
 
       - name: configure sshd
         run: |

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -53,6 +53,7 @@ jobs:
           ip a
           route
           ping -c3 test.el9
+          cat /etc/lxc/default.conf
 
       - name: tests
         run: |

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -52,11 +52,10 @@ jobs:
           set -eux
           ip a
           ping -c3 test.el9
-          ping -4 -c3 google.com
-          ping -6 -c3 google.com
+          curl -I -4 google.com
+          curl -I -6 google.com
           sudo lxc-attach -n el9 -- ip a
           sudo lxc-attach -n el9 -- cat /etc/resolv.conf
-          sudo lxc-attach -n el9 -- ping -6 -c3 google.com
           sudo lxc-attach -n el9 -- curl -6 -I google.com
           sudo lxc-attach -n el9 -- curl -4 -I google.com
 

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -54,9 +54,9 @@ jobs:
           route
           ping -c3 test.el9
           sudo lxc-attach -n el9 -- ip a
+          sudo lxc-attach -n el9 -- route
           sudo lxc-attach -n el9 -- cat /etc/resolv.conf
-          sudo lxc-attach -n el9 -- curl -6 -I google.com
-          sudo lxc-attach -n el9 -- curl -4 -I google.com
+          sudo lxc-attach -n el9 -- curl -vvv -4 -I google.com
 
       - name: configure sshd
         run: |

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -47,6 +47,12 @@ jobs:
           install -m 0700 -d ~/.ssh/
           ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N ''
 
+      - name: test server
+        run: |
+          set -eux
+          python -m http.server &
+          sleep 1
+
       - name: tests
         run: |
           set -eux
@@ -61,6 +67,7 @@ jobs:
           stdbuf -o0 sudo lxc-attach -n el9 -- ip a
           stdbuf -o0 sudo lxc-attach -n el9 -- ip r
           stdbuf -o0 sudo lxc-attach -n el9 -- cat /etc/resolv.conf
+          stdbuf -o0 sudo lxc-attach -n el9 -- curl -vvv -4 -I http://10.0.3.1:8000
           stdbuf -o0 sudo lxc-attach -n el9 -- curl -vvv -4 -I https://google.com
 
       - name: configure sshd

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -58,6 +58,8 @@ jobs:
           sudo iptables -P OUTPUT ACCEPT
           sudo iptables -F
           sudo iptables -X
+          sudo iptables -t nat -F
+          sudo iptables -t nat -X
 
       - name: nat set-up
         run: |

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -55,7 +55,6 @@ jobs:
           ping -c3 test.el9
           sudo lxc-attach -n el9 -- ip a
           sudo lxc-attach -n el9 -- cat /etc/resolv.conf
-          sudo lxc-attach -n el9 -- host google.com
           sudo lxc-attach -n el9 -- curl -6 -I google.com
           sudo lxc-attach -n el9 -- curl -4 -I google.com
 

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -47,6 +47,14 @@ jobs:
           install -m 0700 -d ~/.ssh/
           ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N ''
 
+      - name: tests
+        run: |
+          ip a
+          sudo lxc-attach -n el9 -- ip a
+          sudo lxc-attach -n el9 -- cat /etc/resolv.conf
+          sudo lxc-attach -n el9 -- curl -4 -I google.com
+          sudo lxc-attach -n el9 -- curl -6 -I google.com
+
       - name: configure sshd
         run: |
           sudo lxc-attach -n el9 -- dnf install -y openssh-server

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -60,7 +60,7 @@ jobs:
           set -eux
           sudo lxc-attach -n el9 -- ip a
           sudo lxc-attach -n el9 -- cat /etc/resolv.conf
-          sudo lxc-attach -n el9 -- curl -vvv -4 -I google.com
+          sudo lxc-attach -n el9 -- curl -vvv -4 -I https://google.com
 
       - name: configure sshd
         run: |

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -21,46 +21,16 @@ jobs:
           yamllint
           molecule
 
-      - name: install lxc
-        run: |
-          sudo apt install lxc
-
+      # Disable docker components
       - name: stop docker
         run: |
           sudo systemctl stop docker
 
-      - name: yamllint
+      - name: take docker network down
         run: |
-          yamllint .
+          sudo ip link set dev docker0 down
 
-      - name: ansible-lint
-        run: |
-          ansible-lint
-
-      # yamllint disable rule:line-length
-      - name: create lxc container
-        run: |
-          sudo lxc-create -t download -n el9 -- \
-          --dist centos --release 9-Stream --arch amd64
-          sudo lxc-start --name el9 --daemon
-          while ! sudo lxc-info -n el9 | grep IP; do sleep 0.2; done
-          echo "$(sudo lxc-info -n el9 | sed -n 's/^IP: *//p') test.el9" | sudo tee -a /etc/hosts
-
-      - name: generate ssh key
-        run: |
-          install -m 0700 -d ~/.ssh/
-          ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N ''
-          ls -l ~/.ssh/
-          cp -r ~/.ssh/id_ed25519 ~/.ssh/id_rsa
-
-      - name: configure ssh
-        run: |
-          echo                                    >> ~/.ssh/config
-          echo 'Host test.el9'                    >> ~/.ssh/config
-          echo '  User root'                      >> ~/.ssh/config
-          echo '  IdentityFile ~/.ssh/id_ed25519' >> ~/.ssh/config
-
-      - name: iptables set-up
+      - name: clean up iptables
         run: |
           sudo iptables -P INPUT ACCEPT
           sudo iptables -P FORWARD ACCEPT
@@ -70,55 +40,36 @@ jobs:
           sudo iptables -t nat -F
           sudo iptables -t nat -X
 
+      # LXC set-up
+      - name: install lxc
+        run: |
+          sudo apt install lxc
+
+      # yamllint disable rule:line-length
+      - name: create lxc container
+        run: |
+          sudo lxc-create -t download -n el9 -- --dist centos --release 9-Stream --arch amd64
+          sudo lxc-start --name el9 --daemon
+          while ! sudo lxc-info -n el9 | grep IP; do sleep 0.2; done
+          echo "$(sudo lxc-info -n el9 | sed -n 's/^IP: *//p') test.el9" | sudo tee -a /etc/hosts
+
       - name: nat set-up
         run: |
           sudo iptables -t nat -A POSTROUTING -s '10.0.3.0/24' -o eth0 -j MASQUERADE
 
-      - name: take docker network down
+      - name: generate ssh key
         run: |
-          sudo ip link set dev docker0 down
+          install -m 0700 -d ~/.ssh/
+          ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N ''
 
-      - name: list all iptables rules
+      - name: configure ssh
         run: |
-          sudo iptables -L
+          echo                                    >> ~/.ssh/config
+          echo 'Host test.el9'                    >> ~/.ssh/config
+          echo '  User root'                      >> ~/.ssh/config
+          echo '  IdentityFile ~/.ssh/id_ed25519' >> ~/.ssh/config
 
-      - name: list iptables nat rules
-        run: |
-          sudo iptables -t nat -S
-
-      - name: test server
-        run: |
-          set -eux
-          python -m http.server &
-          sleep 1
-
-      - name: tests
-        run: |
-          set -eux
-          ip a
-          ip r
-          route
-          ping -c3 test.el9
-          cat /etc/lxc/default.conf
-
-      - name: tests
-        run: |
-          set -eux
-          sudo lxc-attach -n el9 -- ip a
-          sudo lxc-attach -n el9 -- ip r
-          sudo lxc-attach -n el9 -- cat /etc/resolv.conf
-          sudo lxc-attach -n el9 -- curl -vvv -4 -I http://10.0.3.1:8000
-
-      - name: tracepath
-        run: |
-          tracepath lkiesow.de
-
-      - name: tests eytern http
-        run: |
-          curl -vvv -4 -I https://lkiesow.de
-          sudo lxc-attach -n el9 -- curl -vvv -4 -I https://lkiesow.de
-
-      - name: configure sshd
+      - name: configure and start sshd
         run: |
           sudo lxc-attach -n el9 -- dnf install -y openssh-server
           sudo lxc-attach -n el9 -- install -m 0700 -d /root/.ssh/
@@ -130,6 +81,17 @@ jobs:
       - name: import ssh keys
         run: |
           ssh-keyscan test.el9 > ~/.ssh/known_hosts
+
+
+      # Run Tests
+
+      - name: yamllint
+        run: |
+          yamllint .
+
+      - name: ansible-lint
+        run: |
+          ansible-lint
 
       - name: run molecule tests
         run: |

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -50,17 +50,18 @@ jobs:
       - name: tests
         run: |
           set -eux
-          ip a
-          route
-          ping -c3 test.el9
-          cat /etc/lxc/default.conf
+          stdbuf -o0 ip a
+          stdbuf -o0 route
+          stdbuf -o0 ping -c3 test.el9
+          stdbuf -o0 cat /etc/lxc/default.conf
 
       - name: tests
         run: |
           set -eux
-          sudo lxc-attach -n el9 -- ip a
-          sudo lxc-attach -n el9 -- cat /etc/resolv.conf
-          sudo lxc-attach -n el9 -- curl -vvv -4 -I https://google.com
+          stdbuf -o0 sudo lxc-attach -n el9 -- ip a
+          stdbuf -o0 sudo lxc-attach -n el9 -- ip r
+          stdbuf -o0 sudo lxc-attach -n el9 -- cat /etc/resolv.conf
+          stdbuf -o0 sudo lxc-attach -n el9 -- curl -vvv -4 -I https://google.com
 
       - name: configure sshd
         run: |

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -25,6 +25,10 @@ jobs:
         run: |
           sudo apt install lxc
 
+      - name: stop docker
+        run: |
+          sudo systemctl stop docker
+
       - name: yamllint
         run: |
           yamllint .

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -86,6 +86,10 @@ jobs:
           sudo lxc-attach -n el9 -- cat /etc/resolv.conf
           sudo lxc-attach -n el9 -- curl -vvv -4 -I http://10.0.3.1:8000
 
+      - name: tracepath
+        run: |
+          tracepath lkiesow.de
+
       - name: tests eytern http
         run: |
           curl -vvv -4 -I https://lkiesow.de

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -51,11 +51,11 @@ jobs:
         run: |
           set -eux
           ip a
+          route
           ping -c3 test.el9
-          curl -I -4 google.com
-          curl -I -6 google.com
           sudo lxc-attach -n el9 -- ip a
           sudo lxc-attach -n el9 -- cat /etc/resolv.conf
+          sudo lxc-attach -n el9 -- host google.com
           sudo lxc-attach -n el9 -- curl -6 -I google.com
           sudo lxc-attach -n el9 -- curl -4 -I google.com
 

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -40,7 +40,7 @@ jobs:
           --dist centos --release 9-Stream --arch amd64
           sudo lxc-start --name el9 --daemon
           while ! sudo lxc-info -n el9 | grep IP; do sleep 0.2; done
-          echo "$(lxc-info -n el9 | sed -n 's/^IP: *//p') test.el9" | sudo tee -a /etc/hosts
+          echo "$(sudo lxc-info -n el9 | sed -n 's/^IP: *//p') test.el9" | sudo tee -a /etc/hosts
 
       - name: generate ssh key
         run: |

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -53,6 +53,13 @@ jobs:
           ls -l ~/.ssh/
           cp -r ~/.ssh/id_ed25519 ~/.ssh/id_rsa
 
+      - name: configure ssh
+        run: |
+          echo                                    >> ~/.ssh/config
+          echo 'Host test.el9'                    >> ~/.ssh/config
+          echo '  User root'                      >> ~/.ssh/config
+          echo '  IdentityFile ~/.ssh/id_ed25519' >> ~/.ssh/config
+
       - name: iptables set-up
         run: |
           sudo iptables -P INPUT ACCEPT

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -53,8 +53,11 @@ jobs:
           ip a
           route
           ping -c3 test.el9
+
+      - name: tests
+        run: |
+          set -eux
           sudo lxc-attach -n el9 -- ip a
-          sudo lxc-attach -n el9 -- route
           sudo lxc-attach -n el9 -- cat /etc/resolv.conf
           sudo lxc-attach -n el9 -- curl -vvv -4 -I google.com
 

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -53,10 +53,6 @@ jobs:
           while ! sudo lxc-info -n el9 | grep IP; do sleep 0.2; done
           echo "$(sudo lxc-info -n el9 | sed -n 's/^IP: *//p') test.el9" | sudo tee -a /etc/hosts
 
-      - name: nat set-up
-        run: |
-          sudo iptables -t nat -A POSTROUTING -s '10.0.3.0/24' -o eth0 -j MASQUERADE
-
       - name: generate ssh key
         run: |
           install -m 0700 -d ~/.ssh/

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -19,7 +19,47 @@ jobs:
           ansible
           ansible-lint
           yamllint
+          molecule
 
-      - run: yamllint .
+      - name: install lxc
+        run: |
+          sudo apt install lxc
 
-      - run: ansible-lint
+      - name: yamllint
+        run: |
+          yamllint .
+
+      - name: ansible-lint
+        run: |
+          ansible-lint
+
+      # yamllint disable rule:line-length
+      - name: create lxc container
+        run: |
+          sudo lxc-create -t download -n el9 -- \
+          --dist centos --release 9-Stream --arch amd64
+          sudo lxc-start --name el9 --daemon
+          while ! sudo lxc-info -n el9 | grep IP; do sleep 0.2; done
+          echo "$(lxc-info -n el9 | sed -n 's/^IP: *//p') test.el9" | sudo tee -a /etc/hosts
+
+      - name: generate ssh key
+        run: |
+          install -m 0700 -d ~/.ssh/
+          ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N ''
+
+      - name: configure sshd
+        run: |
+          sudo lxc-attach -n el9 -- dnf install -y openssh-server
+          sudo lxc-attach -n el9 -- install -m 0700 -d /root/.ssh/
+          cat ~/.ssh/id_ed25519.pub | sudo lxc-attach -n el9 -- tee /root/.ssh/authorized_keys
+          sudo lxc-attach -n el9 -- chmod 0600 /root/.ssh/authorized_keys
+          sudo lxc-attach -n el9 -- systemctl start sshd.service
+
+      # yamllint enable rule:line-length
+      - name: import ssh keys
+        run: |
+          ssh-keyscan test.el9 > ~/.ssh/known_hosts
+
+      - name: run molecule tests
+        run: |
+          molecule test

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -50,6 +50,8 @@ jobs:
         run: |
           install -m 0700 -d ~/.ssh/
           ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N ''
+          ls -l ~/.ssh/
+          cp -r ~/.ssh/id_ed25519 ~/.ssh/id_rsa
 
       - name: iptables set-up
         run: |

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -55,13 +55,13 @@ jobs:
         run: |
           sudo iptables -t nat -A POSTROUTING -s '10.0.3.0/24' -o eth0 -j MASQUERADE
 
-      - name: list iptables rules
-        run: |
-          sudo iptables -L
-
       - name: take docker network down
         run: |
           sudo ip link set dev docker0 down
+
+      - name: list iptables rules
+        run: |
+          sudo iptables -S
 
       - name: test server
         run: |

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -51,6 +51,14 @@ jobs:
           install -m 0700 -d ~/.ssh/
           ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N ''
 
+      - name: iptables set-up
+        run: |
+          iptables -P INPUT ACCEPT
+          iptables -P FORWARD ACCEPT
+          iptables -P OUTPUT ACCEPT
+          iptables -F
+          iptables -X
+
       - name: nat set-up
         run: |
           sudo iptables -t nat -A POSTROUTING -s '10.0.3.0/24' -o eth0 -j MASQUERADE
@@ -59,7 +67,11 @@ jobs:
         run: |
           sudo ip link set dev docker0 down
 
-      - name: list iptables rules
+      - name: list all iptables rules
+        run: |
+          sudo iptables -L
+
+      - name: list iptables nat rules
         run: |
           sudo iptables -t nat -S
 

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -59,6 +59,10 @@ jobs:
         run: |
           sudo iptables -L
 
+      - name: take docker network down
+        run: |
+          sudo ip link set dev docker0 down
+
       - name: test server
         run: |
           set -eux

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -68,7 +68,7 @@ jobs:
           stdbuf -o0 sudo lxc-attach -n el9 -- ip r
           stdbuf -o0 sudo lxc-attach -n el9 -- cat /etc/resolv.conf
           stdbuf -o0 sudo lxc-attach -n el9 -- curl -vvv -4 -I http://10.0.3.1:8000
-          stdbuf -o0 sudo lxc-attach -n el9 -- curl -vvv -4 -I https://google.com
+          stdbuf -o0 sudo lxc-attach -n el9 -- curl -vvv -4 -I https://lkiesow.de
 
       - name: configure sshd
         run: |

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: list iptables rules
         run: |
-          sudo iptables -S
+          sudo iptables -t nat -S
 
       - name: test server
         run: |

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -1,5 +1,0 @@
-FROM quay.io/centos/centos:stream9
-
-RUN dnf -y install systemd
-
-CMD [ "/sbin/init" ]

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -2,18 +2,14 @@
 dependency:
   name: galaxy
 driver:
-  name: podman
+  name: delegated
+  options:
+    managed: false
+    login_cmd_template: ssh {instance}
+    ansible_connection_options:
+      ansible_connection: ssh
 platforms:
-  - name: dnf-autoupdate-centos
-    image: quay.io/centos/centos:stream9
-    pre_build_image: false
-    command: /sbin/init
-    privileged: true
-    tmpfs:
-      - /run
-      - /tmp
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: test.el9
 lint: |
   set -e
   yamllint .


### PR DESCRIPTION
This patch replaces the Podman and Docker based Molecule tests with running them on a pre-configured CentOS Stream 9 LXC container. This gives us a full Systemd based init system with no hacks which behaves much more like an actual production system.