### PR TITLE
Keep Docker network device

### DIFF
--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -26,10 +26,6 @@ jobs:
         run: |
           sudo systemctl stop docker
 
-      - name: take docker network down
-        run: |
-          sudo ip link set dev docker0 down
-
       - name: clean up iptables
         run: |
           sudo iptables -P INPUT ACCEPT


### PR DESCRIPTION
We don't actually take down the docker network interface after removing the iptables rules.