### PR TITLE
Add configuration options for upgrade type and reboot behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,14 @@ Ansible: DNF Autoupdate Role
 
 Ansible role to activate automated package updates via dnf.
 
+Configuration
+-------------
 
+- `dnf_autoupdate_upgrade_type`: kind of upgrade to perform
+- `dnf_autoupdate_reboot`: if the system should reboot automatically
+
+All configuration keys are optional.
+See [defaults](defaults/main.yml) for more details.
 
 Example Playbook
 ----------------
@@ -15,4 +22,6 @@ Example of how to configure and use the role:
   become: true
   roles:
     - role: lkiesow.dnf_autoupdate
+      dnf_autoupdate_upgrade_type: default
+      dnf_autoupdate_reboot: when-needed
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# What kind of upgrade to perform:
+# default       = all available upgrades
+# security      = only the security upgrades
+dnf_autoupdate_upgrade_type: default
+
+# If there should be an automatic reboot after an upate
+# never         = don't reboot after upgrades
+# when-changed  = reboot after any changes
+# when-needed   = reboot when necessary to apply changes
+dnf_autoupdate_reboot: when-needed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,12 @@
 ---
 
+# Automatic reboot was added in EL 9
+- name: Assure at least EL9
+  ansible.builtin.assert:
+    that:
+      - ansible_os_family == 'RedHat'
+      - ansible_facts['distribution_major_version'] | int >= 9
+
 - name: Install dnf-automatic
   ansible.builtin.package:
     name: dnf-automatic
@@ -7,15 +14,17 @@
 - name: Configure automatic updates
   ansible.builtin.lineinfile:
     path: /etc/dnf/automatic.conf
-    regexp: '^{{ item.key }}'
+    regexp: '^{{ item.key }}[ =]'
     line: '{{ item.key }} = {{ item.val }}'
   loop:
     - key: upgrade_type
-      val: default
+      val: '{{ dnf_autoupdate_upgrade_type }}'
     - key: download_updates
       val: 'yes'
     - key: apply_updates
       val: 'yes'
+    - key: reboot
+      val: '{{ dnf_autoupdate_reboot }}'
 
 - name: Enable automatic updates
   ansible.builtin.service:


### PR DESCRIPTION
- Added `dnf_autoupdate_upgrade_type` to specify the kind of upgrade (default, security)
- Added `dnf_autoupdate_reboot` to control automatic reboots after updates
- Created `defaults/main.yml` for default values