### PR TITLE
Add dependabot configuration for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly


### PR DESCRIPTION
Added a new `.github/dependabot.yml` file to configure Dependabot for monthly updates of GitHub Actions dependencies.